### PR TITLE
Add mysqli and pdo_mysql to be suggested extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,5 +24,9 @@
     },
     "require": {
         "php": ">=7.3.0"
+    },
+    "suggest": {
+        "ext-mysqli": "*",
+        "ext-pdo_mysql": "*"
     }
 }


### PR DESCRIPTION
# Changed log

- Adding these two PHP extensions inside `suggest` setting on `composer.json` file.
- It will have suggested message when using the `composer install` command:

```Bash
lee@lee-VirtualBox:~$ php ~/composer.phar update -n
Loading composer repositories with package information
Updating dependencies
Nothing to modify in lock file
Writing lock file
Installing dependencies from lock file (including require-dev)
Nothing to install, update or remove
2 package suggestions were added by new dependencies, use `composer suggest` to see details.
Generating autoload files
lee@lee-VirtualBox:~$ php ~/composer.phar suggest
bringittocode/mop suggests:
 - ext-mysqli: *
 - ext-pdo_mysql: *
```

Without `suggest` setting:

```Bash
lee@lee-VirtualBox:~$ php ~/composer.phar update -n
Loading composer repositories with package information
Updating dependencies
Nothing to modify in lock file
Writing lock file
Installing dependencies from lock file (including require-dev)
Nothing to install, update or remove
2 package suggestions were added by new dependencies, use `composer suggest` to see details.
Generating autoload files

```